### PR TITLE
move Arduino beacon from physical-web repo

### DIFF
--- a/beacons/arduino/README.md
+++ b/beacons/arduino/README.md
@@ -1,0 +1,61 @@
+## Arduino Physical Web Beacon Example
+
+Create a URI Beacon using your [Arduino](http://arduino.cc).
+
+### Supported Hardware (boards/shields)
+
+ * [Nordic Semiconductor nRF8001](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF8001) based
+   * [Adafruit](http://www.adafruit.com)
+     * [Bluefruit LE - nRF8001 Breakout](http://www.adafruit.com/products/1697)
+   * [RedBearLab](http://redbearlab.com)
+     * [BLE Shield](http://redbearlab.com/bleshield/)
+     * [Blend Micro](http://redbearlab.com/blendmicro/)
+     * [Blend](http://redbearlab.com/blend/)
+ * [Nordic Semiconductor nRF51822](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822) based
+   * [RedBearLab](http://redbearlab.com)
+     * [nRF51822](http://redbearlab.com/redbearlab-nrf51822)
+     * [Blend Nano](http://redbearlab.com/blenano)
+
+See [Arduino BLEPeripheral's Compatible Hardware](https://github.com/sandeepmistry/arduino-BLEPeripheral#compatible-hardware) for more info.
+
+[RedBearLab](http://redbearlab.com) products can be purchased from [Seeed Studio](http://www.seeedstudio.com/depot/RedBearLab-m-52.html).
+
+## Using Arduino IDE
+
+#### Setup
+
+Install the [Arduino BLEPeripheral](https://github.com/sandeepmistry/arduino-BLEPeripheral) library. See [Installing Additional Arduino Libraries](http://arduino.cc/en/Guide/Libraries) guide for more info.
+
+##### OS X and Linux
+```
+cd ~/Documents/Arduino/libraries/
+git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
+```
+
+#### Windows
+
+```
+cd "My Documents\Arduino\libraries\"
+git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
+```
+
+#### Running
+
+ 1. Open [physical_web.ino](physical_web/physical_web.ino) sketch
+ 1. Update pin outs in sketch based on hardware setup (```URI_BEACON_REQ```, ```URI_BEACON_RDY```, ```URI_BEACON_RST```)
+ 1. If needed, update flags, power and URI parameters to ```uriBeacon.begin``` in sketch
+ 1. Build and upload to board
+
+__Notes__
+  * only 15 bytes (instead of 18) are available for the URI on nRF8001 based boards/shields, because GAP flags (3 bytes) are in advertisement data
+
+## Using [codebender](https://codebender.cc)
+
+ 1. Open [physical_web_beacon](https://codebender.cc/example/BLEPeripheral/physical_web_beacon) in codebender
+ 1. Update pin outs in sketch based on hardware setup (```URI_BEACON_REQ```, ```URI_BEACON_RDY```, ```URI_BEACON_RST```)
+ 1. If needed, update flags, power and URI parameters to ```uriBeacon.begin``` in sketch
+ 1. Run
+
+
+
+

--- a/beacons/arduino/physical_web/physical_web.ino
+++ b/beacons/arduino/physical_web/physical_web.ino
@@ -1,0 +1,37 @@
+// Import libraries (BLEPeripheral depends on SPI)
+#include <SPI.h>
+#include <BLEPeripheral.h>
+#include <URIBeacon.h>
+
+// define pins (varies per shield/board)
+//
+//   Adafruit Bluefruit LE   10, 2, 9
+//   Blend                    9, 8, UNUSED
+//   Blend Micro              6, 7, 4
+//   RBL BLE Shield           9, 8, UNUSED
+
+#define URI_BEACON_REQ   10
+#define URI_BEACON_RDY   2
+#define URI_BEACON_RST   9
+
+URIBeacon uriBeacon(URI_BEACON_REQ, URI_BEACON_RDY, URI_BEACON_RST);
+
+void setup() {
+  Serial.begin(9600);
+
+#if defined (__AVR_ATmega32U4__)
+  //Wait until the serial port is available (useful only for the Leonardo)
+  //As the Leonardo board is not reseted every time you open the Serial Monitor
+  while(!Serial) {
+  }
+  delay(5000);  //5 seconds delay for enabling to see the start up comments on the serial board
+#endif
+
+  uriBeacon.begin(0x00, 0x20, "http://example.com"); // flags, power, URI
+
+  Serial.println(F("URI Beacon"));
+}
+
+void loop() {
+  uriBeacon.loop();
+}


### PR DESCRIPTION
As per https://github.com/google/physical-web/issues/187, moving Arduino beacon to this repo.

cc: @schilit
