### PR TITLE
RFduino: change power in adv packet to dBm value measured at 0m

### DIFF
--- a/beacons/RFduino/physical_web/physical_web.ino
+++ b/beacons/RFduino/physical_web/physical_web.ino
@@ -11,7 +11,7 @@ uint8_t advdata[] =
   0x16,  // Service Data
   0xD8, 0xFE, // URI Beacon ID
   0x00,  // flags
-  0x20,  // power
+  0xEE,  // power
   0x00,  // http://www.
   'A',
   'B',


### PR DESCRIPTION
Update power field in adv packet to 0xEE, which indicates -18dBm at 0m.

References: https://github.com/google/uribeacon/issues/29
