### PR TITLE
Change initial offset of byte parsing to account for URI Beacon ID

### DIFF
--- a/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/beacon/UriBeacon.java
+++ b/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/beacon/UriBeacon.java
@@ -79,6 +79,8 @@ public class UriBeacon {
     put((byte) 12, ".biz");
     put((byte) 13, ".gov");
   }};
+
+  private static final int URI_BEACON_ID_OFFSET = 2;
   private final byte mFlags;
   private final byte mTxPowerLevel;
   private final String mUriString;
@@ -179,7 +181,8 @@ public class UriBeacon {
     if (serviceData == null || serviceData.length < 3) {
       return null;
     }
-    int currentPos = 0;
+    // We need to account for the URI Beacon ID, which accounts for the first two bytes
+    int currentPos = URI_BEACON_ID_OFFSET;
     byte flags = serviceData[currentPos++];
     byte txPowerLevel = serviceData[currentPos++];
     String uri = decodeUri(serviceData, currentPos);


### PR DESCRIPTION
**Problem:** The Android UriBeacon client was incorrectly parsing the advertisementData format, failing to take into account the initial two bytes consisting of the URI Beacon ID.  This led to an incorrect parsing of the URI and strange data being displayed.  (See UriBeaconAdvertiserActivity, line 59/60 for the reference.)

**Solution:** Specify the offset in the parser code.  

**Before:**

![before](https://cloud.githubusercontent.com/assets/1236394/5227029/e396c9d0-76ed-11e4-8c7c-e9c214474f70.png)

**After:**  

![after](https://cloud.githubusercontent.com/assets/1236394/5227042/008a6006-76ee-11e4-95f4-4fe6019c0d9d.png)
