### PR TITLE
Look for config UUID instead of assuming first one

### DIFF
--- a/android-uribeacon/uribeacon-sample/src/main/java/org/uribeacon/sample/ConfigActivity.java
+++ b/android-uribeacon/uribeacon-sample/src/main/java/org/uribeacon/sample/ConfigActivity.java
@@ -202,12 +202,12 @@ public class ConfigActivity extends Activity implements PasswordDialogFragment.P
       }
       List<ParcelUuid> uuids = scanResult.getScanRecord().getServiceUuids();
       // Check which uuid is the config uuid
-      ParcelUuid services[] = {ProtocolV1.CONFIG_SERVICE_UUID, ProtocolV2.CONFIG_SERVICE_UUID};
-      for (ParcelUuid serviceUuid : services){
-        int uuidIndex= uuids.indexOf(serviceUuid);
-        if (uuidIndex>=0) {
-          mUriBeaconConfig = new UriBeaconConfig(this, mUriBeaconCallback, uuids.get(uuidIndex));
+      ParcelUuid services[] = {ProtocolV2.CONFIG_SERVICE_UUID, ProtocolV1.CONFIG_SERVICE_UUID};
+      for (ParcelUuid serviceUuid : services) {
+        if (uuids.contains(serviceUuid)) {
+          mUriBeaconConfig = new UriBeaconConfig(this, mUriBeaconCallback, serviceUuid);
           mUriBeaconConfig.connectUriBeacon(device);
+          break;
         }
       }
     }


### PR DESCRIPTION
I'm trying to create a uriBeaon and I put service UUID in SCAN RSP data. And I keep Advertisement data the same to examples.

If I'm doing it correctly, UriBeacon app will crash when it try to config this beacon. "uuids" has two uuids and the first one is "FED8", which is not configurable UUID.

Or am I making the Beacon in a wrong way?

Here is SCAN RSP data and Advertisement data

``` c
// GAP - SCAN RSP data (max size = 31 bytes)
static uint8 scanRspData[] =
{
  // complete name
  0x0A,   // length of this data
  GAP_ADTYPE_LOCAL_NAME_COMPLETE,
  0x55,   // 'U'
  0x72,   // 'r'
  0x69,   // 'i'
  0x42,   // 'B'
  0x65,   // 'e'
  0x61,   // 'a'
  0x63,   // 'c'
  0x6f,   // 'o'
  0x6e,   // 'n'

  // service UUID, to notify central devices what services are included
  // in this peripheral
  0x11,   // length of this data
  GAP_ADTYPE_128BIT_MORE,      // some of the UUID's, but not all
  URIBEACON_BASE_UUID_128( URIBEACONPROFILE_SERV_UUID )  
};

// GAP - Advertisement data (max size = 31 bytes, though this is
// best kept short to conserve power while advertisting)
static uint8 advertData[] =
{
  0x02,
  GAP_ADTYPE_FLAGS,
  GAP_ADTYPE_FLAGS_GENERAL|GAP_ADTYPE_FLAGS_BREDR_NOT_SUPPORTED,
  0x03,  // length
  GAP_ADTYPE_16BIT_COMPLETE,  // Param: Service List
  0xD8, 0xFE,  // URI Beacon ID
  0x0A,  // length
  GAP_ADTYPE_SERVICE_DATA,  // Service Data
  0xD8, 0xFE, // URI Beacon ID
  0x00,  // flags
  0xC5,  // power
  0x00,  // http://www.
  'A',
  'B',
  'C',
  0x00,  // .".com"
};
```
