### PR TITLE
Changed order of initialization

### DIFF
--- a/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/config/UriBeaconConfig.java
+++ b/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/config/UriBeaconConfig.java
@@ -76,8 +76,8 @@ public class UriBeaconConfig {
   public void connectUriBeacon(final BluetoothDevice device) {
     // Bind to LocalService
     Intent intent = new Intent(mContext, GattService.class);
-    mContext.bindService(intent, mServiceConnection, Context.BIND_AUTO_CREATE);
     mDevice = device;
+    mContext.bindService(intent, mServiceConnection, Context.BIND_AUTO_CREATE);
   }
 
 


### PR DESCRIPTION
Fixed a problem where the service bound before mDevice got initialized leading to a NPE.
