### PR TITLE
Added ability to insert a series of actions in the builder

### DIFF
--- a/android-uribeacon/uribeacon-validator/src/main/java/org/uribeacon/validator/TestData.java
+++ b/android-uribeacon/uribeacon-validator/src/main/java/org/uribeacon/validator/TestData.java
@@ -1,0 +1,13 @@
+package org.uribeacon.validator;
+
+public class TestData {
+
+  public static byte[] SHORT_LOCK_KEY = new byte[15];
+  public static byte[] BASIC_LOCK_KEY = new byte[16];
+  public static byte[] LONG_LOCK_KEY = new byte[17];
+  public static byte[] UNLOCKED_STATE = new byte[]{0};
+  public static byte[] LOCKED_STATE = new byte[]{1};
+  public static byte[] BASIC_GENERAL_DATA = new byte[]{1};
+  public static byte[] BASIC_TX_POWER = new byte[]{0, 0, 0, 0};
+  public static byte[] BASIC_PERIOD = new byte[]{0x03, (byte) 0xE8};
+}

--- a/android-uribeacon/uribeacon-validator/src/main/java/org/uribeacon/validator/TestHelper.java
+++ b/android-uribeacon/uribeacon-validator/src/main/java/org/uribeacon/validator/TestHelper.java
@@ -390,18 +390,18 @@ public class TestHelper {
       return this;
     }
 
+    public Builder writeAndRead(UUID characteristicUuid, byte[] value) {
+      mTestActions.add(new TestAction(TestAction.WRITE, characteristicUuid, BluetoothGatt.GATT_SUCCESS, value));
+      mTestActions.add(new TestAction(TestAction.ASSERT, characteristicUuid, BluetoothGatt.GATT_SUCCESS, value));
+      return this;
+    }
+    
     public TestHelper build() {
       mTestActions.add(new TestAction(TestAction.LAST));
       // Keep a copy of the steps to show in the UI
       LinkedList<TestAction> testSteps = new LinkedList<>(mTestActions);
       return new TestHelper(mName, mContext, mBluetoothDevice, mServiceUuid, mTestCallback,
           mTestActions, testSteps);
-    }
-
-    public Builder writeAndRead(UUID characteristicUuid, byte[] value) {
-      mTestActions.add(new TestAction(TestAction.WRITE, characteristicUuid, BluetoothGatt.GATT_SUCCESS, value));
-      mTestActions.add(new TestAction(TestAction.ASSERT, characteristicUuid, BluetoothGatt.GATT_SUCCESS, value));
-      return this;
     }
   }
 }

--- a/android-uribeacon/uribeacon-validator/src/main/java/org/uribeacon/validator/TestHelper.java
+++ b/android-uribeacon/uribeacon-validator/src/main/java/org/uribeacon/validator/TestHelper.java
@@ -88,7 +88,7 @@ public class TestHelper {
       super.onCharacteristicRead(gatt, characteristic, status);
       TestAction readTest = mTestActions.peek();
       if (readTest.expectedReturnCode != status) {
-        fail(gatt, "Incorrect status code");
+        fail(gatt, "Incorrect status code: " + status + ". Expected: " + readTest.expectedReturnCode);
       } else if (!Arrays.equals(readTest.transmittedValue, characteristic.getValue())) {
         if (readTest.transmittedValue.length != characteristic.getValue().length) {
           fail(gatt, "Wrong length. Expected: " + new String(readTest.transmittedValue) + ". But received: " + new String(characteristic.getValue()));
@@ -225,6 +225,7 @@ public class TestHelper {
   private void writeToGatt(BluetoothGatt gatt) {
     Log.d(TAG, "Writting");
     TestAction writeTest = mTestActions.peek();
+    Log.d(TAG, "Value: " + Arrays.toString(writeTest.transmittedValue));
     BluetoothGattCharacteristic characteristic = mService
         .getCharacteristic(writeTest.characteristicUuid);
     // WriteType is WRITE_TYPE_NO_RESPONSE even though the one that requests a response
@@ -382,12 +383,25 @@ public class TestHelper {
       return this;
     }
 
+    public Builder insertActions(Builder builder) {
+      for (TestAction action : builder.mTestActions) {
+        mTestActions.add(action);
+      }
+      return this;
+    }
+
     public TestHelper build() {
       mTestActions.add(new TestAction(TestAction.LAST));
       // Keep a copy of the steps to show in the UI
       LinkedList<TestAction> testSteps = new LinkedList<>(mTestActions);
       return new TestHelper(mName, mContext, mBluetoothDevice, mServiceUuid, mTestCallback,
           mTestActions, testSteps);
+    }
+
+    public Builder writeAndRead(UUID characteristicUuid, byte[] value) {
+      mTestActions.add(new TestAction(TestAction.WRITE, characteristicUuid, BluetoothGatt.GATT_SUCCESS, value));
+      mTestActions.add(new TestAction(TestAction.ASSERT, characteristicUuid, BluetoothGatt.GATT_SUCCESS, value));
+      return this;
     }
   }
 }


### PR DESCRIPTION
1. Added one more action to the builder: Write->Read.
2. As I wrote more tests I realized that I would write the same series of actions time and time again. Instead of making TestHelper more complicated, it is now possible to add series of actions to the builder. For example:
```java
Builder lockUnlock = new Builder.write(LOCK, KEY, SUCCESS).write(UNLOCK, KEY, SUCCESS);
TestHelper test = new Builder.connect().insertActions(lockUnlock).disconnect();
```