### PR TITLE
Wrong power for empty beacon

### DIFF
--- a/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/beacon/UriBeacon.java
+++ b/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/beacon/UriBeacon.java
@@ -306,7 +306,7 @@ public class UriBeacon {
   }
 
   private static String decodeUri(byte[] serviceData, int offset) {
-    if (serviceData.length == 0) {
+    if (serviceData.length == offset) {
       return NO_URI;
     }
     StringBuilder uriBuilder = new StringBuilder();

--- a/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/beacon/UriBeacon.java
+++ b/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/beacon/UriBeacon.java
@@ -166,7 +166,7 @@ public class UriBeacon {
   public static UriBeacon parseFromBytes(byte[] scanRecordBytes) {
     byte[] serviceData = parseServiceDataFromBytes(scanRecordBytes);
     // Minimum UriBeacon consists of flags, TxPower
-    if (serviceData == null || serviceData.length < 3) {
+    if (serviceData == null || serviceData.length < 2) {
       return null;
     }
     int currentPos = 0;

--- a/android-uribeacon/uribeacon-sample/src/main/java/org/uribeacon/sample/DeviceListAdapter.java
+++ b/android-uribeacon/uribeacon-sample/src/main/java/org/uribeacon/sample/DeviceListAdapter.java
@@ -74,6 +74,11 @@ class DeviceListAdapter extends ScanResultAdapter {
     if (beacon != null) {
       displayName = beacon.getUriString();
       txPowerLevel = beacon.getTxPowerLevel();
+      // Check if null to avoid null pointer exception.
+      // Check if name is empty if it's empty show other value for displayName
+      if (displayName != null && displayName.isEmpty()) {
+        displayName = null;
+      }
     }
     else {
       txPowerLevel = (byte) scanResult.getScanRecord().getTxPowerLevel();


### PR DESCRIPTION
Fixes #125 

Before:
![wrong tx power before](https://cloud.githubusercontent.com/assets/3117611/6176351/19805240-b2b3-11e4-99fe-e28e51bd7459.png)


After: 
![wrong tx power after](https://cloud.githubusercontent.com/assets/3117611/6176353/1ef6f666-b2b3-11e4-9f80-b6cc37848107.png)
