### PR TITLE
Add myself to the CONTRIBUTORS file and fix a few issues.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@ collinmast
 corymast
 bobkressin
 harshadsabne
+tommythorsen

--- a/android-uribeacon/blescan/build.gradle
+++ b/android-uribeacon/blescan/build.gradle
@@ -24,9 +24,6 @@ android {
     sourceSets {
         main {
             manifest.srcFile 'src/androidTest/AndroidManifest.xml'
-            java {
-                srcDirs = ['src/main/java/org/uribeacon/scan']
-            }
         }
     }
 }
@@ -46,4 +43,5 @@ makeJar.dependsOn(clearJar, build)
 
 dependencies {
     compile 'com.android.support:support-v4:21.0.3'
+    androidTestCompile 'org.mockito:mockito-core:2.0.5-beta'
 }

--- a/android-uribeacon/uribeacon-library/src/androidTest/java/org/uribeacon/scan/compat/BluetoothLeScannerCompatProviderTest.java
+++ b/android-uribeacon/uribeacon-library/src/androidTest/java/org/uribeacon/scan/compat/BluetoothLeScannerCompatProviderTest.java
@@ -24,6 +24,7 @@ import android.app.AlarmManager;
 import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.os.Build;
 import android.test.AndroidTestCase;
 
 import org.uribeacon.scan.compat.BluetoothLeScannerCompat;
@@ -97,10 +98,14 @@ public class BluetoothLeScannerCompatProviderTest extends AndroidTestCase {
     assertNull(BluetoothLeScannerCompatProvider.getBluetoothLeScannerCompat(
         context, canUseNativeApi));
 
-    bluetoothManager = (BluetoothManager) getContext().getSystemService(BLUETOOTH_SERVICE);
-    alarmManager = null;
-    assertNull(BluetoothLeScannerCompatProvider.getBluetoothLeScannerCompat(
-        context, canUseNativeApi));
+    // The alarm manager is not mandatory for creating a bluetooth scanner on
+    // LOLLIPOP (at least not if the right hardware features are supported.)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      bluetoothManager = (BluetoothManager) getContext().getSystemService(BLUETOOTH_SERVICE);
+      alarmManager = null;
+      assertNull(BluetoothLeScannerCompatProvider.getBluetoothLeScannerCompat(
+          context, canUseNativeApi));
+    }
 
     bluetoothManager = null;
     alarmManager = (AlarmManager) getContext().getSystemService(ALARM_SERVICE);


### PR DESCRIPTION
I've added myself to the CONTRIBUTORS file and fixed a couple of issues I encountered when trying to run the unittests.

The first of these issues was that the blescan module was not correctly configured, and would display a bunch of mockito-related errors followed by errors caused by not being able to find the UriBeacon and ConfigUriBeacon classes.

The second unit test issue that failed was the assert that BluetoothLeScannerCompatProvider.getBluetoothLeScannerCompat(...) should return null if there is no ALARM_SERVICE available, which is not the case on my device with LOLLIPOP on it.