### PR TITLE
Add tests for ScreenOffMode.SLOW_SCAN

### DIFF
--- a/android-uribeacon/uribeacon-library/src/androidTest/java/org/uribeacon/scan/controller/ScanControllerTest.java
+++ b/android-uribeacon/uribeacon-library/src/androidTest/java/org/uribeacon/scan/controller/ScanControllerTest.java
@@ -80,35 +80,72 @@ public class ScanControllerTest extends AndroidTestCase {
 
   public void testMotion() {
     mMockContext = new MockContext(mContext);
-    ScanController scanController = new ScanController(mMockContext, 
-        ScanController.ScreenOffMode.NO_SCAN);
-    List<ScanFilter> filters = new ArrayList<ScanFilter>();
 
     ScanSettings.Builder builder = new ScanSettings.Builder();
     builder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES);
     ScanSettings settings = builder.build();
 
-    scanController.startScan(settings, filters, mScanCallback);
+    List<ScanFilter> filters = new ArrayList<ScanFilter>();
 
-    mMockContext.sendScreenOnEvent();
-    assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
+    // Test ScreenOffMode.NO_SCAN
+    {
+      ScanController scanController = new ScanController(mMockContext,
+          ScanController.ScreenOffMode.NO_SCAN);
 
-    scanController.onMotionTimeout();
-    assertEquals(ScanController.ScanState.SLOW_SCAN, scanController.getScanState());
+      scanController.startScan(settings, filters, mScanCallback);
 
-    scanController.onMotion();
-    assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
+      mMockContext.sendScreenOnEvent();
+      assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
 
-    mMockContext.sendScreenOffEvent();
-    assertEquals(ScanController.ScanState.NO_SCAN, scanController.getScanState());
+      scanController.onMotionTimeout();
+      assertEquals(ScanController.ScanState.SLOW_SCAN, scanController.getScanState());
 
-    scanController.onMotionTimeout();
-    assertEquals(ScanController.ScanState.NO_SCAN, scanController.getScanState());
+      scanController.onMotion();
+      assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
 
-    scanController.onMotion();
-    assertEquals(ScanController.ScanState.NO_SCAN, scanController.getScanState());
+      mMockContext.sendScreenOffEvent();
+      assertEquals(ScanController.ScanState.NO_SCAN, scanController.getScanState());
 
-    scanController.unregister();
+      scanController.onMotionTimeout();
+      assertEquals(ScanController.ScanState.NO_SCAN, scanController.getScanState());
+
+      scanController.onMotion();
+      assertEquals(ScanController.ScanState.NO_SCAN, scanController.getScanState());
+
+      scanController.unregister();
+    }
+
+    // Test ScreenOffMode.SLOW_SCAN
+    {
+      ScanController scanController = new ScanController(mMockContext,
+          ScanController.ScreenOffMode.SLOW_SCAN);
+
+      scanController.startScan(settings, filters, mScanCallback);
+
+      mMockContext.sendScreenOnEvent();
+      assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
+
+      scanController.onMotionTimeout();
+      assertEquals(ScanController.ScanState.SLOW_SCAN, scanController.getScanState());
+
+      scanController.onMotion();
+      assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
+
+      mMockContext.sendScreenOffEvent();
+      assertEquals(ScanController.ScanState.SLOW_SCAN, scanController.getScanState());
+
+      scanController.onMotion();
+      assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
+
+      scanController.onMotionTimeout();
+      assertEquals(ScanController.ScanState.SLOW_SCAN, scanController.getScanState());
+
+      mMockContext.sendScreenOnEvent();
+      assertEquals(ScanController.ScanState.FAST_SCAN, scanController.getScanState());
+
+      scanController.unregister();
+    }
+
   }
 }
 

--- a/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/scan/controller/ScanController.java
+++ b/android-uribeacon/uribeacon-library/src/main/java/org/uribeacon/scan/controller/ScanController.java
@@ -264,7 +264,7 @@ public class ScanController implements MotionManager.MotionListener {
        *    SCREEN_ON -> FAST_SCAN
        * SLOW_SCAN
        *    MOTION  ->  FAST_SCAN
-       *    SCREEN_OFF -> SLOW_SCAN
+       *    SCREEN_ON -> FAST_SCAN
        * FAST_SCAN
        *    MOTION_TIMEOUT -> SLOW_SCAN
        *    SCREEN_OFF -> SLOW_SCAN
@@ -276,7 +276,7 @@ public class ScanController implements MotionManager.MotionListener {
 
         put(ScanState.SLOW_SCAN, new HashMap<Event, ScanState>() {{
           put(Event.MOTION, ScanState.FAST_SCAN);
-          put(Event.SCREEN_OFF, ScanState.SLOW_SCAN);
+          put(Event.SCREEN_ON, ScanState.FAST_SCAN);
         }});
 
         put(ScanState.FAST_SCAN, new HashMap<Event, ScanState>() {{


### PR DESCRIPTION
These tests reveal bug in the scan controller when configured with
ScreenOffMode.SLOW_SCAN. The handling for the SCREEN_ON event is missing
from the SLOW_SCAN state, so we add it, and at the same time remove the
useless handling of SCREEN_OFF.
