### PR TITLE
Better support of extensions

### DIFF
--- a/ios-uribeacon/uribeacon-sample/ViewController.m
+++ b/ios-uribeacon/uribeacon-sample/ViewController.m
@@ -45,13 +45,14 @@
            object:[UIApplication sharedApplication]];
 
   // Start the scanner.
-  _scanner = [[UBUriBeaconScanner alloc] init];
+  _scanner = [[UBUriBeaconScanner alloc]
+      initWithApplication:[UIApplication sharedApplication]];
   ViewController *__weak weakSelf = self;
   [_scanner startScanningWithUpdateBlock:^{
-      ViewController *strongSelf = weakSelf;
-      [[strongSelf tableView] reloadData];
-      [strongSelf _openConfiguration];
-      [strongSelf _showLocalNotification];
+    ViewController *strongSelf = weakSelf;
+    [[strongSelf tableView] reloadData];
+    [strongSelf _openConfiguration];
+    [strongSelf _showLocalNotification];
   }];
 
   UIBarButtonItem *settingsButton =
@@ -129,7 +130,7 @@
 }
 
 - (void)configurationViewControllerDismissed:
-            (ConfigureViewController *)controller {
+    (ConfigureViewController *)controller {
   _configureViewController = nil;
 }
 
@@ -148,7 +149,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView
-    numberOfRowsInSection:(NSInteger)section {
+ numberOfRowsInSection:(NSInteger)section {
   return [[_scanner beacons] count];
 }
 

--- a/ios-uribeacon/uribeacon/UBUriBeaconScanner.h
+++ b/ios-uribeacon/uribeacon/UBUriBeaconScanner.h
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class UBUriBeacon;
 @class UBConfigurableUriBeacon;
@@ -27,7 +28,8 @@
  only non-configurable beacons will be discovered.
 
  Here's an example of how to scan beacons:
- <pre><code>_scanner = [[UBUriBeaconScanner alloc] init];
+ <pre><code>_scanner = [[UBUriBeaconScanner alloc]
+     initWithApplication:[UIApplication sharedApplication]];
  [_scanner startScanningWithUpdateBlock:^{
    NSLog(@"beacons: %@", [_scanner beacons]);
    NSLog(@"configurable beacons: %@", [_scanner configurableBeacons]);
@@ -35,6 +37,13 @@
  </code></pre>
  */
 @interface UBUriBeaconScanner : NSObject
+
+/**
+ * Initializes the scanner.
+ * The -[UIApplication sharedApplication] should be given as argument.
+ * If you're running in an extension, you should use nil.
+ */
+- (id)initWithApplication:(UIApplication*)application;
 
 /**
  * Start discovering UriBeacons. It will check frequently for beacon

--- a/ios-uribeacon/uribeacon/UBUriBeaconScanner.m
+++ b/ios-uribeacon/uribeacon/UBUriBeaconScanner.m
@@ -150,6 +150,10 @@ static stateChange stateGraph[] = {
   UIApplication *_application;
 }
 
+- (id)init {
+  return [self initWithApplication:nil];
+}
+
 - (id)initWithApplication:(UIApplication *)application {
   self = [super init];
   if (!self) {

--- a/ios-uribeacon/uribeacon/UBUriBeaconScanner.m
+++ b/ios-uribeacon/uribeacon/UBUriBeaconScanner.m
@@ -125,8 +125,7 @@ static stateChange stateGraph[] = {
      STATE_SCANNING},  // stop scanning, start scanning, set timer
 };
 
-@interface UBUriBeaconScanner () <CBCentralManagerDelegate,
-                                  CBPeripheralDelegate>
+@interface UBUriBeaconScanner ()<CBCentralManagerDelegate, CBPeripheralDelegate>
 
 @end
 
@@ -147,9 +146,11 @@ static stateChange stateGraph[] = {
   NSMutableDictionary *_writers;
   NSMutableDictionary *_readers;
   NSMutableSet *_connectedBeacons;
+
+  UIApplication *_application;
 }
 
-- (id)init {
+- (id)initWithApplication:(UIApplication *)application {
   self = [super init];
   if (!self) {
     return nil;
@@ -161,9 +162,11 @@ static stateChange stateGraph[] = {
       [[CBCentralManager alloc] initWithDelegate:self queue:nil options:nil];
   [_configurableBeaconsCentralManager setDelegate:self];
 
+  _application = application;
   BOOL applicationActive =
-      [[UIApplication sharedApplication] applicationState] ==
-      UIApplicationStateActive;
+      _application != nil
+          ? [_application applicationState] == UIApplicationStateActive
+          : YES;
   _bluetoothOnOrConnected =
       [_beaconsCentralManager state] == CBCentralManagerStatePoweredOn;
   if (applicationActive && _bluetoothOnOrConnected) {
@@ -180,12 +183,12 @@ static stateChange stateGraph[] = {
       addObserver:self
          selector:@selector(_didBecomeActive:)
              name:UIApplicationDidBecomeActiveNotification
-           object:[UIApplication sharedApplication]];
+           object:_application];
   [[NSNotificationCenter defaultCenter]
       addObserver:self
          selector:@selector(_willResignActive:)
              name:UIApplicationWillResignActiveNotification
-           object:[UIApplication sharedApplication]];
+           object:_application];
   _beacons = [NSMutableArray array];
   _configurableBeacons = [NSMutableArray array];
 
@@ -325,9 +328,9 @@ static stateChange stateGraph[] = {
 }
 
 - (void)centralManager:(CBCentralManager *)central
-    didDiscoverPeripheral:(CBPeripheral *)peripheral
-        advertisementData:(NSDictionary *)advertisementData
-                     RSSI:(NSNumber *)RSSI {
+ didDiscoverPeripheral:(CBPeripheral *)peripheral
+     advertisementData:(NSDictionary *)advertisementData
+                  RSSI:(NSNumber *)RSSI {
   if (central == _configurableBeaconsCentralManager) {
     UBConfigurableUriBeacon *configurableBeacon =
         [[UBConfigurableUriBeacon alloc] initWithPeripheral:peripheral
@@ -527,7 +530,7 @@ static stateChange stateGraph[] = {
 }
 
 - (void)centralManager:(CBCentralManager *)central
-    didConnectPeripheral:(CBPeripheral *)peripheral {
+  didConnectPeripheral:(CBPeripheral *)peripheral {
   void (^block)(NSError *error) =
       [_connectionsBlocks objectForKey:[peripheral identifier]];
   [_connectionsBlocks removeObjectForKey:[peripheral identifier]];


### PR DESCRIPTION
Stop referring to -[UIApplication sharedApplication] in UBUriBeaconScanner implementation to make it possible to build it in extensions.

review: @schilit 